### PR TITLE
Fix instructions for usage with Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require 'debugger'; debugger
 
 To use with bundler, drop in your Gemfile:
 
-    gem 'debugger2', :git => "git://github.com/ko1/debugger2.git"
+    gem 'debugger2', :git => "git://github.com/ko1/debugger2.git", require: 'debugger'
 
 ### Configuration
 


### PR DESCRIPTION
This allows usage as:

``` ruby
# test.rb:
require 'bundler'
Bundler.require

p 1
debugger
p 2
```
